### PR TITLE
Fixed Breaking UI

### DIFF
--- a/frontend/src/components/User/core/DiscussionPage.css
+++ b/frontend/src/components/User/core/DiscussionPage.css
@@ -57,6 +57,8 @@
     border-radius: 15px;
     background: #ececec;
     position: relative;
+    word-break: break-all;
+    overflow: hidden;
 }
 
 .msg-info {


### PR DESCRIPTION
## Issue that this pull request solves

 Closes: #31 

## Proposed changes
Brief description of what is fixed or changed
- Files changed
    - DiscussionPage.css

## Types of changes

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots
![image](https://user-images.githubusercontent.com/54680709/96721533-e36f2b80-13c9-11eb-967e-03bbd8d35d3b.png)

## Other information
Found a great way to fix this using css word-break

### Reference
- [Css word-break](https://css-tricks.com/handling-long-unexpected-content-css/#1-use-css-word-break)
